### PR TITLE
feat(performance) Optimize render performance

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,6 +16,8 @@ import { useDispatch } from 'react-redux';
 import { authActions } from '../store/auth';
 import { logoutAPI } from '../lib/api/auth';
 import { userActions } from '../store/user';
+import HeaderAuths from './HeaderAuths';
+import HeaderUserProfile from './HeaderUserProfile';
 
 const Container = styled.div`
   position: sticky;
@@ -120,20 +122,7 @@ const Container = styled.div`
 `;
 
 const Header: React.FC = () => {
-  const dispatch = useDispatch();
-  const { openModal, ModalPortal, closeModal } = useModal();
-  const user = useSelector((state) => state.user);
-
-  const [isUserMenuOpened, setIsUserMenuOpened] = useState(false);
-
-  const logout = async () => {
-    try {
-      await logoutAPI();
-      dispatch(userActions.initUser());
-    } catch (e) {
-      console.log(e.message);
-    }
-  };
+  const isLogged = useSelector((state) => state.user.isLogged);
 
   return (
     <Container>
@@ -143,75 +132,8 @@ const Header: React.FC = () => {
           <AirbnbLogoTextIcon />
         </a>
       </Link>
-      {!user.isLogged && (
-        <div className='header-auth-buttons'>
-          <button
-            type='button'
-            className='header-button header-sign-up-button'
-            onClick={() => {
-              dispatch(authActions.setAuthMode('signup'));
-              openModal();
-            }}
-          >
-            회원가입
-          </button>
-          <button
-            type='button'
-            className='header-button header-login-button'
-            onClick={() => {
-              dispatch(authActions.setAuthMode('login'));
-              openModal();
-            }}
-          >
-            로그인
-          </button>
-        </div>
-      )}
-      {user.isLogged && (
-        <OutsideClickHandler
-          onOutsideClick={() => {
-            if (isUserMenuOpened) {
-              setIsUserMenuOpened(false);
-            }
-          }}
-        >
-          <button
-            className='header-user-profile'
-            type='button'
-            onClick={() => {
-              setIsUserMenuOpened(!isUserMenuOpened);
-            }}
-          >
-            <HamburgerIcon />
-            <img
-              src={user.profileImage}
-              className='header-user-profile-image'
-              alt=''
-            />
-          </button>
-          {isUserMenuOpened && (
-            <ul className='header-usermenu'>
-              <li>숙소 관리</li>
-              <Link href='/room/register/building'>
-                <a
-                  role='presentation'
-                  onClick={() => setIsUserMenuOpened(false)}
-                >
-                  <li>숙소 등록하기</li>
-                </a>
-              </Link>
-              <div className='header-usermenu-divider' />
-              <li role='presentation' onClick={logout}>
-                로그아웃
-              </li>
-            </ul>
-          )}
-        </OutsideClickHandler>
-      )}
-
-      <ModalPortal>
-        <AuthModal closeModal={closeModal} />
-      </ModalPortal>
+      {!isLogged && <HeaderAuths />}
+      {isLogged && <HeaderUserProfile />}
     </Container>
   );
 };

--- a/components/HeaderAuths.tsx
+++ b/components/HeaderAuths.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import AuthModal from './auth/AuthModal';
+import useModal from '../hooks/useModal';
+import { useDispatch } from 'react-redux';
+import { authActions } from '../store/auth';
+
+const HeaderAuths: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const { openModal, ModalPortal, closeModal } = useModal();
+
+  return (
+    <>
+      <div className='header-auth-buttons'>
+        <button
+          type='button'
+          className='header-button header-sign-up-button'
+          onClick={() => {
+            dispatch(authActions.setAuthMode('signup'));
+            openModal();
+          }}
+        >
+          회원가입
+        </button>
+        <button
+          type='button'
+          className='header-button header-login-button'
+          onClick={() => {
+            dispatch(authActions.setAuthMode('login'));
+            openModal();
+          }}
+        >
+          로그인
+        </button>
+      </div>
+
+      <ModalPortal>
+        <AuthModal closeModal={closeModal} />
+      </ModalPortal>
+    </>
+  );
+};
+
+export default HeaderAuths;

--- a/components/HeaderUserProfile.tsx
+++ b/components/HeaderUserProfile.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import Link from 'next/link';
+import OutsideClickHandler from 'react-outside-click-handler';
+
+import HamburgerIcon from '../public/static/svg/header/hamburger.svg';
+
+import { useSelector } from '../store';
+
+import { useDispatch } from 'react-redux';
+import { logoutAPI } from '../lib/api/auth';
+import { userActions } from '../store/user';
+
+const HeaderUserProfile: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const [isUserMenuOpened, setIsUserMenuOpened] = useState(false);
+  const userProfileImage = useSelector((state) => state.user.profileImage);
+
+  const logout = async () => {
+    try {
+      await logoutAPI();
+      dispatch(userActions.initUser());
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
+
+  return (
+    <OutsideClickHandler
+      onOutsideClick={() => {
+        if (isUserMenuOpened) {
+          setIsUserMenuOpened(false);
+        }
+      }}
+    >
+      <button
+        className='header-user-profile'
+        type='button'
+        onClick={() => {
+          setIsUserMenuOpened(!isUserMenuOpened);
+        }}
+      >
+        <HamburgerIcon />
+        <img
+          src={userProfileImage}
+          className='header-user-profile-image'
+          alt=''
+        />
+      </button>
+      {isUserMenuOpened && (
+        <ul className='header-usermenu'>
+          <li>숙소 관리</li>
+          <Link href='/room/register/building'>
+            <a role='presentation' onClick={() => setIsUserMenuOpened(false)}>
+              <li>숙소 등록하기</li>
+            </a>
+          </Link>
+          <div className='header-usermenu-divider' />
+          <li role='presentation' onClick={logout}>
+            로그아웃
+          </li>
+        </ul>
+      )}
+    </OutsideClickHandler>
+  );
+};
+
+export default HeaderUserProfile;

--- a/components/auth/SignUpModal.tsx
+++ b/components/auth/SignUpModal.tsx
@@ -235,6 +235,10 @@ const SignUpModal: React.FC<IProps> = ({ closeModal }) => {
     dispatch(authActions.setAuthMode('login'));
   };
 
+  const disabledMonths = ['월'];
+  const disabledDays = ['일'];
+  const disabledYears = ['년'];
+
   return (
     <Container onSubmit={onSubmitSignUp}>
       <CloseXIcon className='modal-close-x-icon' onClick={closeModal} />
@@ -325,7 +329,7 @@ const SignUpModal: React.FC<IProps> = ({ closeModal }) => {
         <div className='sign-up-modal-birthday-month-selector'>
           <Selector
             options={monthList}
-            disabledOptions={['월']}
+            disabledOptions={disabledMonths}
             defaultValue='월'
             value={birthMonth}
             onChange={onChangeBirthMonth}
@@ -335,7 +339,7 @@ const SignUpModal: React.FC<IProps> = ({ closeModal }) => {
         <div className='sign-up-modal-birthday-day-selector'>
           <Selector
             options={dayList}
-            disabledOptions={['일']}
+            disabledOptions={disabledDays}
             defaultValue='일'
             value={birthDay}
             onChange={onChangeBirthDay}
@@ -345,7 +349,7 @@ const SignUpModal: React.FC<IProps> = ({ closeModal }) => {
         <div className='sign-up-modal-birthday-year-selector'>
           <Selector
             options={yearList}
-            disabledOptions={['년']}
+            disabledOptions={disabledYears}
             defaultValue='년'
             value={birthYear}
             onChange={onChangeBirthYear}

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -22,4 +22,4 @@ const Button: React.FC<IProps> = ({ children, ...props }) => {
   return <Container {...props}>{children}</Container>;
 };
 
-export default Button;
+export default React.memo(Button);

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -89,4 +89,4 @@ const Input: React.FC<IProps> = ({
   );
 };
 
-export default Input;
+export default React.memo(Input);

--- a/components/common/Selector.tsx
+++ b/components/common/Selector.tsx
@@ -68,4 +68,4 @@ const Selector: React.FC<IProps> = ({
   );
 };
 
-export default Selector;
+export default React.memo(Selector);


### PR DESCRIPTION
- 컴포넌트 분리
기존 Header에서 모달 열면 Header 컴포넌트 전체가 렌더링됨
컴포넌트를 분리해서 모달 열때는 해당 부분만 렌더링 되도록 처리 (HeaderAuths, HeaderUserProfile)
- React.memo (props 변경이 되지 않으면 렌더링 막기)
(Input, Selector, Button)
- React Developer Tools 를 활용해서 렌더링 시간 확인 및 최적화 작업